### PR TITLE
fix release.yml YAML syntax, track CHANGELOG.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,4 +102,5 @@ jobs:
       - name: Add release URL to summary
         env:
           RELEASE_URL: ${{ steps.create-release.outputs.html_url }}
-        run: echo "GitHub Release: ${RELEASE_URL}" >> $GITHUB_STEP_SUMMARY
+        run: |
+          echo "GitHub Release: ${RELEASE_URL}" >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary

- Fix YAML syntax error in `release.yml` — `run:` step with a colon in the command must use block scalar (`|`)
- Track `CHANGELOG.md` in git (was incorrectly gitignored)

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` passes
- [x] `CHANGELOG.md` present in repo